### PR TITLE
Add owlstar annotations when parsing OWL

### DIFF
--- a/kgx/prefix_manager.py
+++ b/kgx/prefix_manager.py
@@ -53,6 +53,8 @@ class PrefixManager(object):
                 self.prefix_map[k] = v
         if 'biolink' not in self.prefix_map:
             self.prefix_map['biolink'] = self.prefix_map['@vocab'] if '@vocab' in self.prefix_map else 'https://w3id.org/biolink/vocab/'
+        if 'os' not in self.prefix_map:
+            self.prefix_map['os'] = 'http://w3id.org/owlstar/'
         if '@vocab' in self.prefix_map:
             del self.prefix_map['@vocab']
         if 'MONARCH' not in self.prefix_map:

--- a/kgx/prefix_manager.py
+++ b/kgx/prefix_manager.py
@@ -53,8 +53,8 @@ class PrefixManager(object):
                 self.prefix_map[k] = v
         if 'biolink' not in self.prefix_map:
             self.prefix_map['biolink'] = self.prefix_map['@vocab'] if '@vocab' in self.prefix_map else 'https://w3id.org/biolink/vocab/'
-        if 'os' not in self.prefix_map:
-            self.prefix_map['os'] = 'http://w3id.org/owlstar/'
+        if 'owlstar' not in self.prefix_map:
+            self.prefix_map['owlstar'] = 'http://w3id.org/owlstar/'
         if '@vocab' in self.prefix_map:
             del self.prefix_map['@vocab']
         if 'MONARCH' not in self.prefix_map:

--- a/kgx/transformers/rdf_transformer.py
+++ b/kgx/transformers/rdf_transformer.py
@@ -608,7 +608,7 @@ class RdfOwlTransformer(RdfTransformer):
     def __init__(self, source_graph: Optional[BaseGraph] = None, curie_map: Optional[Dict] = None):
         self.imported: Set = set()
         super().__init__(source_graph, curie_map)
-        self.OS = Namespace('http://w3id.org/owlstar/')
+        self.OWLSTAR = Namespace('http://w3id.org/owlstar/')
 
     def parse(self, filename: str, input_format: Optional[str] = None, compression: Optional[str] = None, provided_by: Optional[str]  = None, node_property_predicates: Optional[Set[str]] = None) -> None:
         """
@@ -697,11 +697,11 @@ class RdfOwlTransformer(RdfTransformer):
                 # owl:someValuesFrom
                 for x in rdfgraph.objects(o, OWL.someValuesFrom):
                     # os:AllSomeInterpretation
-                    os_interpretation = self.OS.term('AllSomeInterpretation')
+                    os_interpretation = self.OWLSTAR.term('AllSomeInterpretation')
                     parent = x
                 # owl:allValuesFrom
                 for x in rdfgraph.objects(o, OWL.allValuesFrom):
-                    os_interpretation = self.OS.term("AllOnlyInterpretation")
+                    os_interpretation = self.OWLSTAR.term("AllOnlyInterpretation")
                     parent = x
                 if pred is None or parent is None:
                     log.warning(f"{s} {p} {o} has OWL.onProperty {pred} and OWL.someValuesFrom {parent}")

--- a/kgx/transformers/rdf_transformer.py
+++ b/kgx/transformers/rdf_transformer.py
@@ -608,6 +608,7 @@ class RdfOwlTransformer(RdfTransformer):
     def __init__(self, source_graph: Optional[BaseGraph] = None, curie_map: Optional[Dict] = None):
         self.imported: Set = set()
         super().__init__(source_graph, curie_map)
+        self.OS = Namespace('http://w3id.org/owlstar/')
 
     def parse(self, filename: str, input_format: Optional[str] = None, compression: Optional[str] = None, provided_by: Optional[str]  = None, node_property_predicates: Optional[Set[str]] = None) -> None:
         """
@@ -681,27 +682,47 @@ class RdfOwlTransformer(RdfTransformer):
         """
         seen = set()
         seen.add(RDFS.subClassOf)
+        reified_nodes = set()
         for s, p, o in rdfgraph.triples((None, RDFS.subClassOf, None)):
             # ignoring blank nodes
             if isinstance(s, rdflib.term.BNode):
                 continue
             pred = None
             parent = None
+            os_interpretation = None
             if isinstance(o, rdflib.term.BNode):
                 # C SubClassOf R some D
                 for x in rdfgraph.objects(o, OWL.onProperty):
                     pred = x
+                # owl:someValuesFrom
                 for x in rdfgraph.objects(o, OWL.someValuesFrom):
+                    # os:AllSomeInterpretation
+                    os_interpretation = self.OS.term('AllSomeInterpretation')
+                    parent = x
+                # owl:allValuesFrom
+                for x in rdfgraph.objects(o, OWL.allValuesFrom):
+                    os_interpretation = self.OS.term("AllOnlyInterpretation")
                     parent = x
                 if pred is None or parent is None:
                     log.warning(f"{s} {p} {o} has OWL.onProperty {pred} and OWL.someValuesFrom {parent}")
                     log.warning("Do not know how to handle BNode: {}".format(o))
+                    for s1,p1,o1 in rdfgraph.triples((o, None, None)):
+                        log.warning(f"{s1} {p1} {o1}")
                     continue
             else:
                 # C SubClassOf D (C and D are named classes)
                 pred = p
                 parent = o
-            self.triple(s, pred, parent)
+            if os_interpretation:
+                eid = generate_uuid()
+                reified_nodes.add(eid)
+                self.triple(URIRef(eid), self.BIOLINK.term('category'), self.BIOLINK.Association)
+                self.triple(URIRef(eid), self.BIOLINK.term('subject'), s)
+                self.triple(URIRef(eid), self.BIOLINK.term('predicate'), pred)
+                self.triple(URIRef(eid), self.BIOLINK.term('object'), parent)
+                self.triple(URIRef(eid), self.BIOLINK.term('logical_interpretation'), os_interpretation)
+            else:
+                self.triple(s, pred, parent)
 
         seen.add(OWL.equivalentClass)
         for s, p, o in rdfgraph.triples((None, OWL.equivalentClass, None)):
@@ -722,5 +743,5 @@ class RdfOwlTransformer(RdfTransformer):
             if p in seen:
                 continue
             self.triple(s, p, o)
-
+        self.dereify(reified_nodes)
         generate_edge_identifiers(self.graph)

--- a/kgx/transformers/rdf_transformer.py
+++ b/kgx/transformers/rdf_transformer.py
@@ -706,8 +706,6 @@ class RdfOwlTransformer(RdfTransformer):
                 if pred is None or parent is None:
                     log.warning(f"{s} {p} {o} has OWL.onProperty {pred} and OWL.someValuesFrom {parent}")
                     log.warning("Do not know how to handle BNode: {}".format(o))
-                    for s1,p1,o1 in rdfgraph.triples((o, None, None)):
-                        log.warning(f"{s1} {p1} {o1}")
                     continue
             else:
                 # C SubClassOf D (C and D are named classes)

--- a/tests/unit/test_rdf_owl_transformer.py
+++ b/tests/unit/test_rdf_owl_transformer.py
@@ -89,3 +89,15 @@ def test_owl_parse2():
 def test_owl_save():
     pass
 
+
+def test_owl_parse3():
+    t = RdfOwlTransformer()
+    t.parse(os.path.join(resource_dir, 'goslim_generic.owl'))
+    e1 = list(t.graph.get_edge('GO:0031012', 'GO:0005576').values())[0]
+    assert e1['predicate'] == 'biolink:part_of'
+    assert e1['relation'] == 'BFO:0000050'
+    assert 'logical_interpretation' in e1 and e1['logical_interpretation'] == 'os:AllSomeInterpretation'
+    e2 = list(t.graph.get_edge('GO:0030705', 'GO:0005622').values())[0]
+    assert e2['predicate'] == 'biolink:occurs_in'
+    assert e2['relation'] == 'BFO:0000066'
+    assert 'logical_interpretation' in e2 and e2['logical_interpretation'] == 'os:AllSomeInterpretation'

--- a/tests/unit/test_rdf_owl_transformer.py
+++ b/tests/unit/test_rdf_owl_transformer.py
@@ -96,8 +96,8 @@ def test_owl_parse3():
     e1 = list(t.graph.get_edge('GO:0031012', 'GO:0005576').values())[0]
     assert e1['predicate'] == 'biolink:part_of'
     assert e1['relation'] == 'BFO:0000050'
-    assert 'logical_interpretation' in e1 and e1['logical_interpretation'] == 'os:AllSomeInterpretation'
+    assert 'logical_interpretation' in e1 and e1['logical_interpretation'] == 'owlstar:AllSomeInterpretation'
     e2 = list(t.graph.get_edge('GO:0030705', 'GO:0005622').values())[0]
     assert e2['predicate'] == 'biolink:occurs_in'
     assert e2['relation'] == 'BFO:0000066'
-    assert 'logical_interpretation' in e2 and e2['logical_interpretation'] == 'os:AllSomeInterpretation'
+    assert 'logical_interpretation' in e2 and e2['logical_interpretation'] == 'owlstar:AllSomeInterpretation'


### PR DESCRIPTION
This PR adds the ability to add owlstar annotations when parsing OWL files.

Currently it adds the following owlstar annotations:
- rdfs:subClassOf -> owl:Restriction -> owl:someValuesFrom
  - `os:AllSomeInterpretation`
- rdfs:subClassOf -> owl:Restriction -> owl:allValuesFrom
  - `os:AllOnlyInterpretation`

Addresses https://github.com/biolink/kgx/issues/163