### PR TITLE
Fix TSV export

### DIFF
--- a/kgx/sink/sink.py
+++ b/kgx/sink/sink.py
@@ -10,8 +10,8 @@ class Sink(object):
     """
     def __init__(self):
         self.prefix_manager = PrefixManager()
-        self._node_properties = {}
-        self._edge_properties = {}
+        self.node_properties = set()
+        self.edge_properties = set()
 
     def set_reverse_prefix_map(self, m: Dict) -> None:
         """

--- a/kgx/sink/tsv_sink.py
+++ b/kgx/sink/tsv_sink.py
@@ -7,6 +7,10 @@ from kgx.sink.sink import Sink
 from kgx.utils.kgx_utils import extension_types, archive_write_mode, archive_format, remove_null, _sanitize_export
 
 
+DEFAULT_NODE_COLUMNS = {'id', 'name', 'category', 'description', 'provided_by'}
+DEFAULT_EDGE_COLUMNS = {'id', 'subject', 'predicate', 'object', 'relation', 'category', 'provided_by'}
+
+
 class TsvSink(Sink):
     """
     TsvSink is responsible for writing data as records to a TSV/CSV.
@@ -37,9 +41,9 @@ class TsvSink(Sink):
         if self.dirname:
             os.makedirs(self.dirname, exist_ok=True)
 
-        self._node_properties = set(kwargs['node_properties']) if 'node_properties' in kwargs else set()
+        self._node_properties = set(kwargs['node_properties']) if 'node_properties' in kwargs else DEFAULT_NODE_COLUMNS
         self.ordered_node_columns = TsvSink._order_node_columns(self._node_properties)
-        self._edge_properties = set(kwargs['edge_properties']) if 'edge_properties' in kwargs else set()
+        self._edge_properties = set(kwargs['edge_properties']) if 'edge_properties' in kwargs else DEFAULT_EDGE_COLUMNS
         self.ordered_edge_columns = TsvSink._order_edge_columns(self._edge_properties)
 
         self.nodes_file_name = os.path.join(self.dirname if self.dirname else '', self.nodes_file_basename)
@@ -194,3 +198,11 @@ class TsvSink(Sink):
         ordered_columns.update(sorted(remaining_columns))
         ordered_columns.update(sorted(internal_columns))
         return ordered_columns
+
+    def set_node_properties(self, np):
+        self._node_properties.update(np)
+        self.ordered_node_columns = TsvSink._order_node_columns(self._node_properties)
+
+    def set_edge_properties(self, ep):
+        self._edge_properties = ep
+        self.ordered_edge_columns = TsvSink._order_edge_columns(self._edge_properties)

--- a/kgx/source/graph_source.py
+++ b/kgx/source/graph_source.py
@@ -48,6 +48,7 @@ class GraphSource(Source):
             if 'provided_by' in self.graph_metadata and 'provided_by' not in node_data.keys():
                 node_data['provided_by'] = self.graph_metadata['provided_by']
             if self.check_node_filter(node_data):
+                self.node_properties.update(node_data.keys())
                 yield n, node_data
 
     def read_edges(self) -> Generator:
@@ -60,4 +61,5 @@ class GraphSource(Source):
             if 'provided_by' in self.graph_metadata and 'provided_by' not in edge_data.keys():
                 edge_data['provided_by'] = self.graph_metadata['provided_by']
             if self.check_edge_filter(edge_data):
+                self.node_properties.update(edge_data.keys())
                 yield u, v, k, edge_data

--- a/kgx/source/neo_source.py
+++ b/kgx/source/neo_source.py
@@ -239,6 +239,7 @@ class NeoSource(Source):
             node['provided_by'] = self.graph_metadata['provided_by']
         node = validate_node(node)
         node = sanitize_import(node.copy())
+        self.node_properties.update(node.keys())
         return node['id'], node
 
     def load_edges(self, edges: List) -> None:
@@ -292,6 +293,7 @@ class NeoSource(Source):
         key = generate_edge_key(subject_node['id'], edge['predicate'], object_node['id'])
         edge = validate_edge(edge)
         edge = sanitize_import(edge.copy())
+        self.edge_properties.update(edge.keys())
         return subject_node['id'], object_node['id'], key, edge
 
     def get_pages(self, query_function, start: int = 0, end: Optional[int] = None, page_size: int = 50000, **kwargs: Any) -> Iterator:

--- a/kgx/source/rdf_source.py
+++ b/kgx/source/rdf_source.py
@@ -135,6 +135,7 @@ class RdfSource(Source):
             if 'provided_by' in self.graph_metadata and 'provided_by' not in data.keys():
                 data['provided_by'] = self.graph_metadata['provided_by']
             if self.check_node_filter(data):
+                self.node_properties.update(data.keys())
                 yield k, data
         self.node_cache.clear()
 
@@ -145,6 +146,7 @@ class RdfSource(Source):
             if 'provided_by' in self.graph_metadata and 'provided_by' not in data.keys():
                 data['provided_by'] = self.graph_metadata['provided_by']
             if self.check_edge_filter(data):
+                self.edge_properties.update(data.keys())
                 yield k[0], k[1], k[2], data
         self.edge_cache.clear()
 
@@ -221,6 +223,7 @@ class RdfSource(Source):
                 if 'provided_by' in self.graph_metadata and 'provided_by' not in data.keys():
                     data['provided_by'] = self.graph_metadata['provided_by']
                 if self.check_edge_filter(data):
+                    self.edge_properties.update(data.keys())
                     yield k[0], k[1], k[2], data
             self.edge_cache.clear()
         yield None

--- a/kgx/source/source.py
+++ b/kgx/source/source.py
@@ -15,8 +15,8 @@ class Source(object):
         self.graph_metadata: Dict = {}
         self.node_filters = {}
         self.edge_filters = {}
-        self._node_properties = set()
-        self._edge_properties = set()
+        self.node_properties = set()
+        self.edge_properties = set()
         self.prefix_manager = PrefixManager()
 
     def set_prefix_map(self, m: Dict) -> None:

--- a/tests/integration/test_stream_transform.py
+++ b/tests/integration/test_stream_transform.py
@@ -11,6 +11,8 @@ def _stream_transform(query):
     t1 = Transformer(stream=True)
     for i in query[0]:
         t1.transform(i)
+        # TODO: Direct stream
+        #t1.transform(i, query[1])
     t1.save(query[1])
 
     if query[1]['format'] in {'tsv', 'csv', 'jsonl'}:

--- a/tests/integration/test_transform.py
+++ b/tests/integration/test_transform.py
@@ -7,13 +7,48 @@ from tests.integration import clean_slate, DEFAULT_NEO4J_URL, DEFAULT_NEO4J_USER
 
 
 def _transform(query):
-    t = Transformer()
+    t1 = Transformer()
     for i in query[0]:
-        t.transform(i)
-    print_graph(t.store.graph)
-    t.save(query[1])
-    assert t.store.graph.number_of_nodes() == query[2]
-    assert t.store.graph.number_of_edges() == query[3]
+        t1.transform(i)
+    print_graph(t1.store.graph)
+    t1.save(query[1].copy())
+    assert t1.store.graph.number_of_nodes() == query[2]
+    assert t1.store.graph.number_of_edges() == query[3]
+
+    if query[1]['format'] in {'tsv', 'csv', 'jsonl'}:
+        input_args = []
+        ia1 = {
+            'filename': f"{query[1]['filename']}_nodes.{query[1]['format']}",
+            'format': query[1]['format']
+        }
+        ia2 = {
+            'filename': f"{query[1]['filename']}_edges.{query[1]['format']}",
+            'format': query[1]['format']
+        }
+        input_args.append(ia1)
+        input_args.append(ia2)
+    elif query[1]['format'] in {'neo4j'}:
+        input_args = [
+            {
+                'uri': DEFAULT_NEO4J_URL,
+                'username': DEFAULT_NEO4J_USERNAME,
+                'password': DEFAULT_NEO4J_PASSWORD,
+                'format': 'neo4j'
+            }
+        ]
+    else:
+        input_args = [
+            {
+                'filename': query[1]['filename'],
+                'format': query[1]['format']
+            }
+        ]
+
+    t2 = Transformer()
+    for i in input_args:
+        t2.transform(i)
+    assert t2.store.graph.number_of_nodes() == query[2]
+    assert t2.store.graph.number_of_edges() == query[3]
 
 
 @pytest.mark.parametrize('query', [
@@ -57,11 +92,13 @@ def _transform(query):
         [
             {
                 'filename': os.path.join(RESOURCE_DIR, 'graph_nodes.tsv'),
-                'format': 'tsv'
+                'format': 'tsv',
+                'lineterminator': None
             },
             {
                 'filename': os.path.join(RESOURCE_DIR, 'graph_edges.tsv'),
-                'format': 'tsv'
+                'format': 'tsv',
+                'lineterminator': None
             },
         ],
         {
@@ -157,6 +194,24 @@ def _transform(query):
         },
         133,
         13
+    ),
+    (
+        [
+            {
+                'filename': os.path.join(RESOURCE_DIR, 'graph_nodes.tsv'),
+                'format': 'tsv'
+            },
+            {
+                'filename': os.path.join(RESOURCE_DIR, 'graph_edges.tsv'),
+                'format': 'tsv'
+            },
+        ],
+        {
+            'filename': os.path.join(TARGET_DIR, 'graph1'),
+            'format': 'tsv'
+        },
+        512,
+        532
     ),
 ])
 def test_transform1(clean_slate, query):


### PR DESCRIPTION
Fix TSV/CSV export by keeping track of node and edge properties.

When in stream mode, if user doesn't supply `node_properties` and `edge_properties` for output, default to a subset of node and edge properties.