### PR TITLE
Assign default category to nodes when incoming category is invalid

### DIFF
--- a/kgx/transformers/sssom_transformer.py
+++ b/kgx/transformers/sssom_transformer.py
@@ -192,9 +192,15 @@ class SssomTransformer(Transformer):
         for k, v in edge.items():
             if k in SSSOM_NODE_PROPERTY_MAPPING:
                 if k.startswith('subject'):
-                    subject_node[SSSOM_NODE_PROPERTY_MAPPING[k]] = v
+                    mapped_k = SSSOM_NODE_PROPERTY_MAPPING[k]
+                    if mapped_k == 'category' and not PrefixManager.is_curie(v):
+                        v = f"biolink:OntologyClass"
+                    subject_node[mapped_k] = v
                 elif k.startswith('object'):
-                    object_node[SSSOM_NODE_PROPERTY_MAPPING[k]] = v
+                    mapped_k = SSSOM_NODE_PROPERTY_MAPPING[k]
+                    if mapped_k == 'category' and not PrefixManager.is_curie(v):
+                        v = f"biolink:OntologyClass"
+                    object_node[mapped_k] = v
                 else:
                     log.info(f"Ignoring {k} {v}")
             else:


### PR DESCRIPTION
Assign a default `biolink:OntologyClass` category to a node when the incoming category (via `subject_category` or `object_category`) has an invalid category.

The criteria for invalid category is whether or not the category value is a CURIE.