### PR TITLE
Resolves issue #308

### DIFF
--- a/kgx/source/jsonl_source.py
+++ b/kgx/source/jsonl_source.py
@@ -3,6 +3,9 @@ import re
 import jsonlines
 from typing import Optional, Any, Generator
 
+from kgx.config import get_logger
+log = get_logger()
+
 from kgx.source.json_source import JsonSource
 
 
@@ -52,7 +55,9 @@ class JsonlSource(JsonSource):
         elif re.search(f'edges.{format}', filename):
             m = self.read_edge
         else:
-            raise TypeError(f"Unrecognized file: {filename}")
+            # This used to throw an exception but perhaps we should simply ignore it.
+            log.warning(f'Parse function cannot resolve the KGX file type in name {filename}. Skipped...')
+            return
 
         if compression == 'gz':
             with gzip.open(filename, 'rb') as FH:

--- a/kgx/source/rdf_source.py
+++ b/kgx/source/rdf_source.py
@@ -305,7 +305,7 @@ class RdfSource(Source):
         if 'subject' in node and 'object' in node:
             self.add_edge(node['subject'], node['object'], node['predicate'], node)
         else:
-            raise ValueError(f"Incomplete node {n} {node}")
+            log.warning(f"Missing 'subject' or 'object' in reified edge node {n} {node}. Ignoring the edge....")
 
     def add_node_attribute(
         self, iri: Union[URIRef, str], key: str, value: Union[str, List]

--- a/kgx/source/tsv_source.py
+++ b/kgx/source/tsv_source.py
@@ -175,7 +175,8 @@ class TsvSource(Source):
                     self.edge_properties.update(chunk.columns)
                     yield from self.read_edges(chunk)
             else:
-                raise Exception(f'Unrecognized file: {filename}')
+                # This used to throw an exception but perhaps we should simply ignore it.
+                log.warning(f'Parse function cannot resolve the KGX file type in name {filename}. Skipped...')
 
     def read_nodes(self, df: pd.DataFrame) -> Generator:
         """


### PR DESCRIPTION
Especially in the dereify method of the RDF  Source, but also  elsewhere.

Basically, instead of hard processing exceptions, use log messages and data (and file) skipping