### PR TITLE
Issue 307 validator biolink release aware

### DIFF
--- a/docs/reference/validator.md
+++ b/docs/reference/validator.md
@@ -14,6 +14,10 @@ v.validate(graph)
 
 For very large graphs, the Validator operation may now successfully process graph data equally well using data streaming (command flag `--stream=True`) which significantly minimizes the memory footprint required to process such graphs.
 
+## Biolink Model Versioning
+
+By default, the Validator validates against the latest Biolink Model release supported by the current Biolink Model Toolkit, but this default may be overridden at the Validator class level using the `Validator.set_biolink_model(version="#.#.#")` where  **#.#.#**  is the _major.minor.patch_ semantic versioning of the desired Biolink Model release.  The kgx **validate** CLI operation also has an optional `biolink_release` argument for the same purpose.
+
 ## kgx.validator
 
 

--- a/kgx/cli/__init__.py
+++ b/kgx/cli/__init__.py
@@ -156,8 +156,18 @@ def graph_summary_wrapper(
     help='File to write validation reports to',
 )
 @click.option('--stream', '-s', is_flag=True, help='Parse input as a stream')
+@click.option('--biolink-release',
+              '-b',
+              required=False,
+              help='Biolink Model Release (SemVer) used for validation (default: latest Biolink Model Toolkit version)'
+)
 def validate_wrapper(
-    inputs: List[str], input_format: str, input_compression: str, output: str, stream: bool
+        inputs: List[str],
+        input_format: str,
+        input_compression: str,
+        output: str,
+        stream: bool,
+        biolink_release: str = None
 ):
     """
     Run KGX validator on an input file to check for Biolink Model compliance.
@@ -175,9 +185,10 @@ def validate_wrapper(
         Path to output file
     stream: bool
         Whether to parse input as a stream
-
+    biolink_release: Optional[str]
+        SemVer version of Biolink Model Release used for validation (default: latest Biolink Model Toolkit version)
     """
-    validate(inputs, input_format, input_compression, output, stream)
+    validate(inputs, input_format, input_compression, output, stream, biolink_release)
 
 
 @cli.command(name='neo4j-download')

--- a/kgx/cli/cli_utils.py
+++ b/kgx/cli/cli_utils.py
@@ -11,7 +11,7 @@ import yaml
 from kgx.validator import Validator
 from kgx.sink import Sink
 from kgx.transformer import Transformer, SOURCE_MAP, SINK_MAP
-from kgx.config import get_logger, get_biolink_model_schema
+from kgx.config import get_logger
 from kgx.graph.base_graph import BaseGraph
 from kgx.graph_operations.graph_merge import merge_all_graphs
 from kgx.graph_operations import summarize_graph, meta_knowledge_graph
@@ -192,11 +192,8 @@ def validate(
     # First, we instantiate a Validator() class (converted into a Callable class) as an Inspector ...
     # In the new "Inspector" design pattern, we need to instantiate it before the Transformer.
     #
-
-    if biolink_release:
-        validator = Validator(schema=get_biolink_model_schema(biolink_release))
-    else:
-        validator = Validator()
+    validator = Validator()
+    Validator.set_biolink_model(biolink_release)
 
     if stream:
         transformer = Transformer(stream=stream)

--- a/kgx/cli/cli_utils.py
+++ b/kgx/cli/cli_utils.py
@@ -11,7 +11,7 @@ import yaml
 from kgx.validator import Validator
 from kgx.sink import Sink
 from kgx.transformer import Transformer, SOURCE_MAP, SINK_MAP
-from kgx.config import get_logger
+from kgx.config import get_logger, get_biolink_model_schema
 from kgx.graph.base_graph import BaseGraph
 from kgx.graph_operations.graph_merge import merge_all_graphs
 from kgx.graph_operations import summarize_graph, meta_knowledge_graph
@@ -161,6 +161,7 @@ def validate(
     input_compression: Optional[str],
     output: Optional[str],
     stream: bool,
+    biolink_release: Optional[str] = None
 ) -> List:
     """
     Run KGX validator on an input file to check for Biolink Model compliance.
@@ -177,6 +178,8 @@ def validate(
         Path to output file (stdout, by default)
     stream: bool
          Whether to parse input as a stream.
+    biolink_release: Optional[str] = None
+        SemVer version of Biolink Model Release used for validation (default: latest Biolink Model Toolkit version)
     Returns
     -------
     List
@@ -189,9 +192,13 @@ def validate(
     # First, we instantiate a Validator() class (converted into a Callable class) as an Inspector ...
     # In the new "Inspector" design pattern, we need to instantiate it before the Transformer.
     #
-    if stream:
+
+    if biolink_release:
+        validator = Validator(schema=get_biolink_model_schema(biolink_release))
+    else:
         validator = Validator()
-        
+
+    if stream:
         transformer = Transformer(stream=stream)
         
         transformer.transform(
@@ -210,7 +217,6 @@ def validate(
         transformer.transform(
             {'filename': inputs, 'format': input_format, 'compression': input_compression},
         )
-        validator = Validator()
         
         # Slight tweak of classical 'validate' function: that the
         # list of errors are cached internally in the Validator object

--- a/kgx/config.py
+++ b/kgx/config.py
@@ -128,8 +128,12 @@ semver_pattern = re.compile(r"^\d+\.\d+\.\d+$")
 
 
 def get_biolink_model_schema(biolink_release: Optional[str] = None) -> Optional[str]:
-    if not biolink_release or not semver_pattern.fullmatch(biolink_release):
-        return None
-    else:
+    if biolink_release:
+        if not semver_pattern.fullmatch(biolink_release):
+            raise TypeError(
+                "The 'biolink_release' argument '"+biolink_release+
+                "' is not a properly formatted 'major.minor.patch' semantic version?")
         schema = f"https://raw.githubusercontent.com/biolink/biolink-model/{biolink_release}/biolink-model.yaml"
         return schema
+    else:
+        return None

--- a/kgx/config.py
+++ b/kgx/config.py
@@ -1,12 +1,14 @@
 import importlib
-import logging
+from typing import Dict, Any, Optional
 import sys
 from os import path
-import json
-from typing import Dict, Any, Optional
+
+import re
 
 import requests
 import yaml
+import json
+import logging
 
 from kgx.graph.base_graph import BaseGraph
 
@@ -119,3 +121,15 @@ def get_graph_store_class() -> Any:
         class_name = name.split('.')[-1]
         graph_store_class = getattr(importlib.import_module(module_name), class_name)
     return graph_store_class
+
+
+# Biolink Release number should be a well formed Semantic Versioning (patch is optional?)
+semver_pattern = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def get_biolink_model_schema(biolink_release: Optional[str] = None) -> Optional[str]:
+    if not biolink_release or not semver_pattern.fullmatch(biolink_release):
+        return None
+    else:
+        schema = f"https://raw.githubusercontent.com/biolink/biolink-model/{biolink_release}/biolink-model.yaml"
+        return schema

--- a/kgx/utils/kgx_utils.py
+++ b/kgx/utils/kgx_utils.py
@@ -261,6 +261,12 @@ def get_toolkit(schema: Optional[str] = None) -> Toolkit:
     """
     Get an instance of bmt.Toolkit
     If there no instance defined, then one is instantiated and returned.
+
+    Parameters
+    ----------
+    schema: Optional[str]
+        Url to (Biolink) Model Schema to be used for validated (default: None, use default Biolink Model Toolkit schema)
+
     """
     global toolkit
     if toolkit is None:

--- a/kgx/utils/kgx_utils.py
+++ b/kgx/utils/kgx_utils.py
@@ -19,10 +19,10 @@ import numpy as np
 from prefixcommons.curie_util import contract_uri
 from prefixcommons.curie_util import expand_uri
 
-from kgx.config import get_jsonld_context, get_logger, get_config
+from kgx.config import get_logger, get_jsonld_context, get_biolink_model_schema
 from kgx.graph.base_graph import BaseGraph
 
-toolkit = None
+default_toolkit = None
 curie_lookup_service = None
 cache = None
 
@@ -257,28 +257,25 @@ def expand(curie: str, prefix_maps: Optional[List[dict]] = None, fallback: bool 
     return uri
 
 
-def get_toolkit(schema: Optional[str] = None) -> Toolkit:
+def get_toolkit(biolink_release: Optional[str] = None) -> Toolkit:
     """
     Get an instance of bmt.Toolkit
     If there no instance defined, then one is instantiated and returned.
 
     Parameters
     ----------
-    schema: Optional[str]
-        Url to (Biolink) Model Schema to be used for validated (default: None, use default Biolink Model Toolkit schema)
+    biolink_release: Optional[str]
+        URL to (Biolink) Model Schema to be used for validated (default: None, use default Biolink Model Toolkit schema)
 
     """
-    global toolkit
-    if toolkit is None:
-        # We no longer assume that the KGX config containsthe default schema
-        # but rather  now, defer schema resolution to the Biolink Model Toolkit default.
-        #
-        # if not schema:
-        #     config = get_config()
-        #     schema = config['biolink-model']
-        #
-        toolkit = Toolkit(schema=schema) if schema else Toolkit()
-
+    global default_toolkit
+    if biolink_release:
+        schema = get_biolink_model_schema(biolink_release)
+        toolkit = Toolkit(schema=schema)
+    else:
+        if default_toolkit is None:
+            default_toolkit = Toolkit()
+        toolkit = default_toolkit
     return toolkit
 
 
@@ -452,7 +449,7 @@ def get_type_for_property(p: str) -> str:
     """
     Get type for a property.
 
-    TODO: Move this to biolink-model-toolkit
+    TODO: Move this to biolink-model-default_toolkit
 
     Parameters
     ----------

--- a/kgx/validator.py
+++ b/kgx/validator.py
@@ -110,19 +110,22 @@ class Validator(object):
         Whether the generated report should be verbose or not (default: ``False``)
     progress_monitor: Optional[Callable[[GraphEntityType, List], None]]
         Function given a peek at the current record being processed by the class wrapped Callable.
+    schema: Optional[str]
+        URL to (Biolink) Model Schema to be used for validated (default: None, use default Biolink Model Toolkit schema)
     """
     
     def __init__(
             self,
             verbose: bool = False,
-            progress_monitor: Optional[Callable[[GraphEntityType, List], None]] = None
+            progress_monitor: Optional[Callable[[GraphEntityType, List], None]] = None,
+            schema: Optional[str] = None
     ):
         # formal arguments
         self.verbose: bool = verbose
         self.progress_monitor: Optional[Callable[[GraphEntityType, List], None]] = progress_monitor
 
         # internal attributes
-        self.toolkit = get_toolkit()
+        self.toolkit = get_toolkit(schema)
         self.prefix_manager = PrefixManager()
         self.jsonld = get_jsonld_context()
         self.prefixes = Validator.get_all_prefixes(self.jsonld)

--- a/tests/integration/test_validator.py
+++ b/tests/integration/test_validator.py
@@ -1,5 +1,6 @@
 import os
 
+from kgx.config import get_biolink_model_schema
 from kgx.validator import Validator
 from kgx.graph.nx_graph import NxGraph
 from kgx.transformer import Transformer
@@ -53,3 +54,30 @@ def test_validate_json():
     validator = Validator()
     e = validator.validate(t.store.graph)
     assert len(e) == 0
+
+
+def test_validator_explicit_biolink_version():
+    """
+    A fake test to establish a success condition for validation.
+    """
+    G = NxGraph()
+    G.add_node('CHEMBL.COMPOUND:1222250', id='CHEMBL.COMPOUND:1222250', name='Dextrose', category=['Carbohydrate'])
+    G.add_node('UBERON:0000001', id='UBERON:0000001', name='fake', category=['NamedThing'])
+    G.add_edge(
+        'CHEMBL.COMPOUND:1222250',
+        'UBERON:0000001',
+        id='CHEMBL.COMPOUND:1222250-part_of-UBERON:0000001',
+        relation='RO:1',
+        predicate='part_of',
+        subject='CHEMBL.COMPOUND:1222250',
+        object='UBERON:0000001',
+        category=['biolink:Association'],
+    )
+    validator = Validator(
+        verbose=True,
+        schema=get_biolink_model_schema("1.8.2")
+    )
+    e = validator.validate(G)
+    print(validator.report(e))
+    assert len(e) == 0
+

--- a/tests/integration/test_validator.py
+++ b/tests/integration/test_validator.py
@@ -73,10 +73,8 @@ def test_validator_explicit_biolink_version():
         object='UBERON:0000001',
         category=['biolink:Association'],
     )
-    validator = Validator(
-        verbose=True,
-        schema=get_biolink_model_schema("1.8.2")
-    )
+    validator = Validator(verbose=True)
+    Validator.set_biolink_model(version="1.8.2")
     e = validator.validate(G)
     print(validator.report(e))
     assert len(e) == 0

--- a/tests/integration/test_validator.py
+++ b/tests/integration/test_validator.py
@@ -1,6 +1,6 @@
 import os
 
-from kgx.config import get_biolink_model_schema
+from kgx.utils.kgx_utils import get_toolkit
 from kgx.validator import Validator
 from kgx.graph.nx_graph import NxGraph
 from kgx.transformer import Transformer
@@ -79,3 +79,9 @@ def test_validator_explicit_biolink_version():
     print(validator.report(e))
     assert len(e) == 0
 
+
+def test_distinct_persistent_validator_biolink_version():
+    Validator.set_biolink_model(version="1.8.2")
+    default_tk = get_toolkit()
+    validator_tk = Validator.get_toolkit()
+    assert(default_tk.get_model_version() != validator_tk.get_model_version())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,18 @@
+import pytest
+
+from kgx.config import get_biolink_model_schema
+
+
+def test_valid_biolink_version():
+    try:
+        schema = get_biolink_model_schema("2.0.2")
+    except TypeError as te:
+        assert False, "test failure!"
+    assert(schema == 'https://raw.githubusercontent.com/biolink/biolink-model/2.0.2/biolink-model.yaml')
+
+
+def test_invalid_biolink_version():
+    try:
+        schema = get_biolink_model_schema()
+    except TypeError as te:
+        assert True, "Type error expected: passed the invalid non-semver, type error: " + str(te)

--- a/tests/unit/test_kgx_utils.py
+++ b/tests/unit/test_kgx_utils.py
@@ -32,7 +32,7 @@ from kgx.utils.kgx_utils import (
 def test_get_toolkit():
     """
     Test to get an instance of Toolkit via get_toolkit and
-    check if default toolkit biolink model version.
+    check if default default_toolkit biolink model version.
     """
     tk = get_toolkit()
     assert isinstance(tk, Toolkit)

--- a/tests/unit/test_kgx_utils.py
+++ b/tests/unit/test_kgx_utils.py
@@ -32,7 +32,7 @@ from kgx.utils.kgx_utils import (
 def test_get_toolkit():
     """
     Test to get an instance of Toolkit via get_toolkit and
-    check if default default_toolkit biolink model version.
+    check if default is the default biolink model version.
     """
     tk = get_toolkit()
     assert isinstance(tk, Toolkit)


### PR DESCRIPTION
The KGX validator may now optionally be set to validate on a specific Biolink Model (semver) version. This can be done in two ways:

1. If the `Validator()` class is being directly (programmatically) called, then a new class method `Validator.set_biolink_model(release="target-release")` may be called before  or after creation of the Validator() class, but before any module  (including static) methods are called.
2. The SemVer can be directly specified on the CLI 'validate' command

