### PR TITLE
anchor rdflib in version 5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pandas>=1.0.3
 pytest>=0.0
 mypy>=0.0
 pystache>=0.0
-rdflib>=0.0
+rdflib==5.0.0
 Click~=7.0
 neo4jrestclient>=0.0
 pyyaml>=0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pandas>=1.0.3
 pytest>=0.0
 mypy>=0.0
 pystache>=0.0
-rdflib==5.0.0
+rdflib~=5.0.0
 Click~=7.0
 neo4jrestclient>=0.0
 pyyaml>=0.0


### PR DESCRIPTION
rdflib version 6.0 appears to have some breaking changes affecting kgx:

```
    from kgx.transformer import Transformer, SOURCE_MAP, SINK_MAP
  File "/venv/lib/python3.8/site-packages/kgx/transformer.py", line 7, in <module>
    from kgx.source import (
  File "/venv/lib/python3.8/site-packages/kgx/source/__init__.py", line 8, in <module>
    from .rdf_source import RdfSource
  File "/venv/lib/python3.8/site-packages/kgx/source/rdf_source.py", line 10, in <module>
    from kgx.parsers.ntriples_parser import CustomNTriplesParser
  File "/venv/lib/python3.8/site-packages/kgx/parsers/ntriples_parser.py", line 4, in <module>
    from rdflib.plugins.parsers.ntriples import NTriplesParser, ParseError
ImportError: cannot import name 'NTriplesParser' from 'rdflib.plugins.parsers.ntriples' (/venv/lib/python3.8/site-packages/rdflib/plugins/parsers/ntriples.py)
```