### PR TITLE
Issue 315: Raise exception when N-Triples parser encounters an empty line in NT file

### DIFF
--- a/kgx/parsers/ntriples_parser.py
+++ b/kgx/parsers/ntriples_parser.py
@@ -39,7 +39,9 @@ class CustomNTriplesParser(NTriplesParser):
             if self.line is None:
                 break
             if self.line == "":
-                raise ParseError(f"Empty line encountered in {filename}")
+                raise ParseError(f"Empty line encountered in {filename}. "
+                                 f"Ensure that no leading or trailing empty lines persist "
+                                 f"in the N-Triples file.")
                 break
             try:
                 yield from self.parseline()

--- a/kgx/parsers/ntriples_parser.py
+++ b/kgx/parsers/ntriples_parser.py
@@ -39,6 +39,7 @@ class CustomNTriplesParser(NTriplesParser):
             if self.line is None:
                 break
             if self.line == "":
+                raise ParseError(f"Empty line encountered in {filename}")
                 break
             try:
                 yield from self.parseline()


### PR DESCRIPTION
This PR address the issue where KGX was failing silently when it encounters an empty line in the NT file. This PR ensures that KGX raises an exception and provides necessary hints on the error.