### PR TITLE
Remove pystache from requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ SPARQLWrapper>=1.8.2
 pandas>=1.0.3
 pytest>=0.0
 mypy>=0.0
-pystache>=0.0
 rdflib~=5.0.0
 Click~=7.0
 neo4jrestclient>=0.0


### PR DESCRIPTION
`kgx` still requires `pystache`, but the last reference to that package in the code has been removed with commit efe630ca. I assume its continued presence in `requirements.txt` is an oversight, so this PR removes it.