### PR TITLE
Fix get_biolink_model_schema method to accept semantic version with v as prefix

### DIFF
--- a/kgx/config.py
+++ b/kgx/config.py
@@ -123,8 +123,8 @@ def get_graph_store_class() -> Any:
     return graph_store_class
 
 
-# Biolink Release number should be a well formed Semantic Versioning (patch is optional?)
-semver_pattern = re.compile(r"^\d+\.\d+\.\d+$")
+# Biolink Release number should be a well formed Semantic Versioning or with a 'v' as prefix (patch is optional?)
+semver_pattern = re.compile(r"^v?\d+\.\d+\.\d+$")
 
 
 def get_biolink_model_schema(biolink_release: Optional[str] = None) -> Optional[str]:
@@ -136,7 +136,7 @@ def get_biolink_model_schema(biolink_release: Optional[str] = None) -> Optional[
             raise TypeError(
                 "The 'biolink_release' argument '"
                 + biolink_release
-                + "' is not a properly formatted 'major.minor.patch' semantic version?"
+                + "' is not a properly formatted 'major.minor.patch' or v'major.minor.pathc' version"
             )
         schema = f"https://raw.githubusercontent.com/biolink/biolink-model/{biolink_release}/biolink-model.yaml"
         return schema

--- a/kgx/config.py
+++ b/kgx/config.py
@@ -136,7 +136,7 @@ def get_biolink_model_schema(biolink_release: Optional[str] = None) -> Optional[
             raise TypeError(
                 "The 'biolink_release' argument '"
                 + biolink_release
-                + "' is not a properly formatted 'major.minor.patch' or v'major.minor.pathc' version"
+                + "' is not a properly formatted 'major.minor.patch' or v'major.minor.patch' version"
             )
         schema = f"https://raw.githubusercontent.com/biolink/biolink-model/{biolink_release}/biolink-model.yaml"
         return schema


### PR DESCRIPTION
I fixed a bug mentioned in the issue #421 