### PR TITLE
Replace `prefixcommons` usages with `curies`

### DIFF
--- a/kgx/prefix_manager.py
+++ b/kgx/prefix_manager.py
@@ -1,7 +1,7 @@
 import re
 from typing import Dict, Optional
 
-import prefixcommons.curie_util as cu
+import curies
 from cachetools import LRUCache, cached
 
 from kgx.config import get_jsonld_context, get_logger
@@ -33,7 +33,8 @@ class PrefixManager(object):
 
         """
         if url:
-            context = cu.read_remote_jsonld_context(url)
+            converter = curies.load_jsonld_context(url)
+            context = converter.bimap
         else:
             context = get_jsonld_context()
         self.set_prefix_map(context)

--- a/kgx/utils/kgx_utils.py
+++ b/kgx/utils/kgx_utils.py
@@ -21,8 +21,8 @@ from bmt import Toolkit
 from cachetools import LRUCache
 import pandas as pd
 import numpy as np
-from prefixcommons.curie_util import contract_uri
-from prefixcommons.curie_util import expand_uri
+import curies
+
 from kgx.config import get_logger, get_jsonld_context, get_biolink_model_schema
 from kgx.graph.base_graph import BaseGraph
 
@@ -220,12 +220,41 @@ def format_biolink_slots(s: str) -> str:
         return f"biolink:{formatted}"
 
 
+BUILTIN_PREFIX_MAP = {
+    "biolink": "https://w3id.org/biolink/vocab/",
+    "owlstar": "http://w3id.org/owlstar/",
+    "MONARCH": "https://monarchinitiative.org/",
+    "MONARCH_NODE": "https://monarchinitiative.org/MONARCH_",
+}
+BUILTIN_CONVERTER = curies.Converter.from_prefix_map(BUILTIN_PREFIX_MAP)
+MONARCH_CONVERTER = curies.load_prefix_map(get_jsonld_context("monarch_context"))
+OBO_CONVERTER = curies.load_prefix_map(get_jsonld_context("obo_context"))
+DEFAULT_CONVERTER = curies.chain([
+    BUILTIN_CONVERTER,
+    MONARCH_CONVERTER,
+    OBO_CONVERTER
+])
+
+
+def _resolve_converter(prefix_maps) -> curies.Converter:
+    if not prefix_maps:
+        return DEFAULT_CONVERTER
+    return curies.chain([
+        BUILTIN_CONVERTER,
+        *(
+            curies.load_prefix_map(prefix_map)
+            for prefix_map in prefix_maps
+        ),
+        MONARCH_CONVERTER,
+        OBO_CONVERTER,
+    ])
+
+
 def contract(
     uri: str, prefix_maps: Optional[List[Dict]] = None, fallback: bool = True
 ) -> str:
     """
     Contract a given URI to a CURIE, based on mappings from `prefix_maps`.
-    If no prefix map is provided then will use defaults from prefixcommons-py.
 
     This method will return the URI as the CURIE if there is no mapping found.
 
@@ -236,8 +265,7 @@ def contract(
     prefix_maps: Optional[List[Dict]]
         A list of prefix maps to use for mapping
     fallback: bool
-        Determines whether to fallback to default prefix mappings, as determined
-        by `prefixcommons.curie_util`, when URI prefix is not found in `prefix_maps`.
+        Defunct option. New implementation always chains with default prefix maps.
 
     Returns
     -------
@@ -245,26 +273,7 @@ def contract(
         A CURIE corresponding to the URI
 
     """
-    curie = uri
-    default_curie_maps = [
-        get_jsonld_context("monarch_context"),
-        get_jsonld_context("obo_context"),
-    ]
-    if prefix_maps:
-        curie_list = contract_uri(uri, prefix_maps)
-        if len(curie_list) == 0:
-            if fallback:
-                curie_list = contract_uri(uri, default_curie_maps)
-                if curie_list:
-                    curie = curie_list[0]
-        else:
-            curie = curie_list[0]
-    else:
-        curie_list = contract_uri(uri, default_curie_maps)
-        if len(curie_list) > 0:
-            curie = curie_list[0]
-
-    return curie
+    return _resolve_converter(prefix_maps).compress(uri, passthrough=True)
 
 
 def expand(
@@ -282,8 +291,7 @@ def expand(
     prefix_maps: Optional[List[dict]]
         A list of prefix maps to use for mapping
     fallback: bool
-        Determines whether to fallback to default prefix mappings, as determined
-        by `prefixcommons.curie_util`, when CURIE prefix is not found in `prefix_maps`.
+        Defunct option. New implementation always chains with default prefix maps.
 
     Returns
     -------
@@ -291,18 +299,7 @@ def expand(
         A URI corresponding to the CURIE
 
     """
-    default_curie_maps = [
-        get_jsonld_context("monarch_context"),
-        get_jsonld_context("obo_context"),
-    ]
-    if prefix_maps:
-        uri = expand_uri(curie, prefix_maps)
-        if uri == curie and fallback:
-            uri = expand_uri(curie, default_curie_maps)
-    else:
-        uri = expand_uri(curie, default_curie_maps)
-
-    return uri
+    return _resolve_converter(prefix_maps).expand(curie, passthrough=True)
 
 
 _default_toolkit = None


### PR DESCRIPTION
This PR replaces usages of `prefixcommons` with `curies`. This is the first step towards more principled management of I/O of prefix maps that has the following benefits:

1. Prefix map chaining is done using a tested and well-defined algorithm `curies.chain`
2. Compression uses a fast and correct Trie data structure
3. We replace the internal implementation of expansion and compression with a well-tested one

Next steps after this PR will be to replace the usage of the contract and expand functions directly using `curies.Converter`, which will have a massive speed gain.