### PR TITLE
Issue#470 - fix propagation of 'deprecate' metadata flag

### DIFF
--- a/kgx/source/obograph_source.py
+++ b/kgx/source/obograph_source.py
@@ -1,5 +1,4 @@
 import gzip
-import tarfile
 import typing
 from itertools import chain
 from typing import Optional, Tuple, Dict, Generator, Any
@@ -104,6 +103,9 @@ class ObographSource(JsonSource):
         curie = self.prefix_manager.contract(node["id"])
         node_properties = {}
         if "meta" in node:
+            # Returns a dictionary that contains 'description', 'subsets',
+            # 'synonym', 'xrefs', a 'deprecated' flag and/or
+            # 'equivalent_nodes', if the corresponding key values are set
             node_properties = self.parse_meta(node["id"], node["meta"])
 
         fixed_node = dict()
@@ -114,12 +116,18 @@ class ObographSource(JsonSource):
 
         if "description" in node_properties:
             fixed_node["description"] = node_properties["description"]
-        if "synonym" in node_properties:
-            fixed_node["synonym"] = node_properties["synonym"]
-        if "xrefs" in node_properties:
-            fixed_node["xref"] = node_properties["xrefs"]
+
         if "subsets" in node_properties:
             fixed_node["subsets"] = node_properties["subsets"]
+
+        if "synonym" in node_properties:
+            fixed_node["synonym"] = node_properties["synonym"]
+
+        if "xrefs" in node_properties:
+            fixed_node["xref"] = node_properties["xrefs"]
+
+        if "deprecated" in node_properties:
+            fixed_node["deprecated"] = node_properties["deprecated"]
 
         if "category" not in node:
             category = self.get_category(curie, node)
@@ -127,9 +135,11 @@ class ObographSource(JsonSource):
                 fixed_node["category"] = [category]
             else:
                 fixed_node["category"] = ["biolink:OntologyClass"]
+
         if "equivalent_nodes" in node_properties:
             equivalent_nodes = node_properties["equivalent_nodes"]
             fixed_node["same_as"] = equivalent_nodes
+
         return super().read_node(fixed_node)
 
     def read_edges(self, filename: str, compression: Optional[str] = None) -> Generator:
@@ -301,8 +311,8 @@ class ObographSource(JsonSource):
         Returns
         -------
         Dict
-            A dictionary that contains 'description', 'synonyms',
-            'xrefs', and 'equivalent_nodes'.
+            A dictionary that contains 'description', 'subsets',
+            'synonyms', 'xrefs', a 'deprecated' flag and/or 'equivalent_nodes'.
 
         """
         # cross species links are in meta; this needs to be parsed properly too

--- a/tests/resources/phenio.json
+++ b/tests/resources/phenio.json
@@ -1,0 +1,53 @@
+{
+  "graphs": [
+    {
+      "nodes": [
+        {
+          "id": "http://purl.obolibrary.org/obo/GO_0051370",
+          "lbl": "obsolete ZASP binding",
+          "type": "INDIVIDUAL",
+          "meta": {
+            "definition": {
+              "val": "OBSOLETE. Binding to Z-band alternatively spliced PDZ motif protein (ZASP). ZASP is a Z-band protein specifically expressed in heart and skeletal muscle. This protein contains N-terminal PDZ domain and C-terminal LIM domain.",
+              "xrefs": [
+                "PMID:10427098",
+                "PMID:11699871"
+              ]
+            },
+            "comments": [
+              "This term was made obsolete because it represents binding to an individual protein."
+            ],
+            "synonyms": [
+              {
+                "pred": "hasExactSynonym",
+                "val": "Z-band alternatively spliced PDZ-motif protein binding"
+              },
+              {
+                "pred": "hasExactSynonym",
+                "val": "ZASP binding"
+              }
+            ],
+            "basicPropertyValues": [
+              {
+                "pred": "http://purl.obolibrary.org/obo/IAO_0100001",
+                "val": "GO:0008092"
+              },
+              {
+                "pred": "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+                "val": "molecular_function"
+              }
+            ],
+            "deprecated": true
+          }
+        }
+      ],
+      "edges": [],
+      "id": "http://purl.obolibrary.org/obo/phenio.owl",
+      "meta": {
+        "subsets": [],
+        "xrefs": [],
+        "basicPropertyValues": []
+      }
+    }
+  ]
+}

--- a/tests/unit/test_source/test_obograph_source.py
+++ b/tests/unit/test_source/test_obograph_source.py
@@ -107,6 +107,29 @@ def test_read_jsonl2():
     assert "GO slim generic" in n2["provided_by"]
 
 
+def test_read_deprecated_term():
+    """
+    Read from an PATO JSON using ObographSource,
+    to validate capture of "deprecate" status
+    """
+    t = Transformer()
+    s = ObographSource(t)
+    g = s.parse(
+        os.path.join(RESOURCE_DIR, "pato.json"),
+        knowledge_source="Phenotype and Trait Ontology",
+    )
+    nodes = {}
+    for rec in g:
+        if rec:
+            if len(rec) != 4:
+                nodes[rec[0]] = rec[1]
+
+    n1 = nodes["PATO:0000000"]
+    assert n1["id"] == "PATO:0000000"
+    assert n1["name"] == "obsolete pato"
+    assert n1["deprecated"] is True
+
+
 @pytest.mark.parametrize(
     "query",
     [


### PR DESCRIPTION
Partially resolves issue #470: Although the above parse_meta() was parsing in the 'deprecated' tag, it wasn't being propagated by the caller code. In fact, neither was 'subsets'. 

I'm continuing the review a bit longer in case the issue is not yet fully resolved for all pertinent use cases.