### PR TITLE
add "parquet source" mapped to "GraphSource" to support parquet sink support

### DIFF
--- a/docs/reference/sink.md
+++ b/docs/reference/sink.md
@@ -142,3 +142,18 @@ formatted JSON.
    :inherited-members:
    :show-inheritance:
 ```
+
+
+## kgx.sink.parquet_sink
+
+`ParquetSink` is responsible for writing data as Parquet table files.
+
+KGX writes two separate files - one for nodes and another for edges.
+
+
+```eval_rst
+.. automodule:: kgx.sink.parquet_sink
+   :members:
+   :inherited-members:
+   :show-inheritance:
+```

--- a/kgx/__init__.py
+++ b/kgx/__init__.py
@@ -1,4 +1,8 @@
-"""
-KGX Package
-"""
-__version__ = "2.1.0"
+# use importlib.metadata to read the version provided
+# by the package during installation. Do not hardcode
+# the version in the code
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
+__version__ = importlib_metadata.version(__name__)

--- a/kgx/transformer.py
+++ b/kgx/transformer.py
@@ -50,6 +50,7 @@ SOURCE_MAP = {
     "nt": RdfSource,
     "owl": OwlSource,
     "sssom": SssomSource,
+    "parquet": GraphSource,
 }
 
 SINK_MAP = {


### PR DESCRIPTION
- also: remove hardcoding of kgx version number instead using importlib