### PR TITLE
Checks if synonym val exists before access

### DIFF
--- a/kgx/source/obograph_source.py
+++ b/kgx/source/obograph_source.py
@@ -333,7 +333,7 @@ class ObographSource(JsonSource):
 
         if "synonyms" in meta:
             # parse 'synonyms' as 'synonym'
-            synonyms = [s["val"] for s in meta["synonyms"]]
+            synonyms = [s["val"] for s in meta["synonyms"] if "val" in s]
             properties["synonym"] = synonyms
 
         if "xrefs" in meta:


### PR DESCRIPTION
The current obographs serialiser creates

```
{
      "id" : "http://purl.obolibrary.org/obo/OBA_2050220",
      "lbl" : "vascular cell adhesion protein 1 amount",
      "type" : "CLASS",
      "meta" : {
        "definition" : {
          "val" : "The amount of a vascular cell adhesion protein 1 when measured in anatomical entity.",
          "xrefs" : [ "AUTO:patterns/patterns/entity_attribute_location" ]
        },
        "synonyms" : [ {
          "pred" : "hasExactSynonym"
        }]
      }
    }
```

So we need to check if the value exists before accessing it to not fail hard.

This is not tested.