### PR TITLE
Fix DuckDB source to handle single-valued category fields

### DIFF
--- a/kgx/source/duckdb_source.py
+++ b/kgx/source/duckdb_source.py
@@ -287,16 +287,24 @@ class DuckDbSource(Source):
         Process a node dictionary into KGX format.
         """
         try:
+            # Get category, ensuring it's a list for downstream processing
+            category = node_data.get('category', 'biolink:NamedThing')
+            if isinstance(category, str):
+                # Handle pipe-delimited categories or single category
+                category = [c.strip() for c in category.split('|') if c.strip()]
+            elif not isinstance(category, list):
+                category = [str(category)] if category else ['biolink:NamedThing']
+
             node = {
                 'id': node_data['id'],
-                'category': node_data.get('category', 'biolink:NamedThing')
+                'category': category
             }
-            
+
             # Add other properties
             for key, value in node_data.items():
                 if key not in ['id', 'category'] and value is not None:
                     node[key] = value
-            
+
             # Return (node_id, node_data) format expected by transformer
             return (node_data['id'], node)
         except Exception as e:


### PR DESCRIPTION
## Summary
- Fix `DuckDbSource.process_node()` to ensure category is always returned as a list
- Handles single string values, pipe-delimited strings, and edge cases

## Problem
When reading from DuckDB databases where `category` is stored as a single string value (e.g., `"biolink:Gene"` rather than a list), the `graph-summary` command produced empty node category statistics. 

The issue was that `GraphSummary.analyse_node()` iterates over `categories`, and when passed a string instead of a list, it iterates character-by-character, resulting in invalid single-character "categories" that fail validation.

## Solution
Convert category to a list in `process_node()`:
- Single string → `["biolink:Gene"]`
- Pipe-delimited → `["biolink:Gene", "biolink:NamedThing"]`
- Already a list → unchanged

## Test plan
- [x] Tested with monarch-kg DuckDB database
- [x] Verified `kgx graph-summary` now produces proper category breakdowns
- [x] Output increased from 326 lines to 1,774 lines with proper statistics

🤖 Generated with [Claude Code](https://claude.com/claude-code)