### PR TITLE
Preserve ArangoDB collection names ...

### DIFF
--- a/kgx/source/arango_source.py
+++ b/kgx/source/arango_source.py
@@ -223,7 +223,7 @@ class ArangoSource(Source):
                 if "id" not in doc:
                     doc["id"] = f"{node_collection}:{key}"
                 doc.setdefault("name", "")
-                doc.setdefault("category", ["biolink:NamedThing"])
+                doc.setdefault("category", ["biolink:NamedThing", node_collection])
                 nodes.append(doc)
         except Exception as e:
             log.error(e)
@@ -293,21 +293,30 @@ class ArangoSource(Source):
                 to_ref = edge_data.pop("_to", "")
                 subject_curie = _arango_ref_to_curie(from_ref)
                 object_curie = _arango_ref_to_curie(to_ref)
+                subj_collection = from_ref.split("/", 1)[0] if "/" in from_ref else ""
+                obj_collection = to_ref.split("/", 1)[0] if "/" in to_ref else ""
+
+                subj_category = ["biolink:NamedThing"]
+                if subj_collection:
+                    subj_category.append(subj_collection)
+                obj_category = ["biolink:NamedThing"]
+                if obj_collection:
+                    obj_category.append(obj_collection)
 
                 subject_node.pop("_key", "")
                 if "id" not in subject_node:
                     subject_node["id"] = subject_curie
                 subject_node.setdefault("name", "")
-                subject_node.setdefault("category", ["biolink:NamedThing"])
+                subject_node.setdefault("category", subj_category)
 
                 object_node.pop("_key", "")
                 if "id" not in object_node:
                     object_node["id"] = object_curie
                 object_node.setdefault("name", "")
-                object_node.setdefault("category", ["biolink:NamedThing"])
+                object_node.setdefault("category", obj_category)
 
-                edge_data.setdefault("predicate", "biolink:related_to")
-                edge_data.setdefault("relation", "biolink:related_to")
+                edge_data.setdefault("predicate", edge_collection)
+                edge_data.setdefault("relation", edge_collection)
 
                 edges.append([subject_node, edge_data, object_node])
         except Exception as e:


### PR DESCRIPTION
## ... as node categories and edge predicates

### Problem

`kgx arangodb-download` was collapsing all node labels to `:NamedThing` and all edge types to `:related_to` in the downstream Neo4j graph. Vertex and edge documents in ArangoDB dumps often carry their semantic type in the *collection name* (e.g. `CL`, `GO`, `UBERON` for nodes; `subclass_of`, `part_of`, `expresses` for edges) rather than in a stored `category`/`predicate` field — but `arango_source.py` only fell back to the biolink defaults (`biolink:NamedThing`, `biolink:related_to`) when those fields were absent, erasing the distinctions.

### Fix

In `kgx/source/arango_source.py`, when a document has no stored `category`/`predicate`, derive the missing value from the collection name:

- **Nodes**: `category` → `["biolink:NamedThing", <vertex_collection>]`. `NamedThing` stays so biolink-aware tooling still sees a valid category; the collection name is appended as an additional Neo4j label.
- **Edge subject/object** (reconstructed via `DOCUMENT(edge._from/_to)`): same treatment, collection parsed from `_from`/`_to`.
- **Edges**: `predicate` and `relation` default to the edge-collection name (bare, no `biolink:` prefix).

Documents that *do* store `category`/`predicate` are untouched — the collection name is only a fallback, preserving round-trip behavior for properly annotated datasets.

### Testing

- 7 ArangoDB unit tests and 2 integration round-trip tests pass unchanged (they exercise the stored-value path).
- Manually verified against a NLM-CKN dump: nodes now surface their collection name as a Neo4j label; edges surface the collection name as the relationship type.
