### PR TITLE
Fix obograph_source prefix-map destruction and predicate mapping

### DIFF
--- a/kgx/source/obograph_source.py
+++ b/kgx/source/obograph_source.py
@@ -203,7 +203,12 @@ class ObographSource(JsonSource):
                 element = get_biolink_element(curie)
                 if not element:
                     try:
-                        mapping = self.toolkit.get_element_by_mapping(edge["pred"])
+                        # bmt's get_element_by_mapping recognizes CURIE form
+                        # (e.g. "RO:0002162"), not IRIs. The CURIE is computed
+                        # above as `curie`; passing the IRI here silently falls
+                        # back to biolink:related_to for relations that have a
+                        # perfectly good biolink slot mapping.
+                        mapping = self.toolkit.get_element_by_mapping(curie)
                         if mapping:
                             element = self.toolkit.get_element(mapping)
 

--- a/kgx/source/sssom_source.py
+++ b/kgx/source/sssom_source.py
@@ -51,7 +51,10 @@ class SssomSource(Source):
             Prefix to IRI map
 
         """
-        self.prefix_manager.set_prefix_map(m)
+        # See TsvSource.set_prefix_map for the rationale: use update (additive)
+        # rather than set (destructive) so the JSON-LD context defaults aren't
+        # discarded when a caller passes no overrides.
+        self.prefix_manager.update_prefix_map(m)
 
     def set_reverse_prefix_map(self, m: Dict) -> None:
         """

--- a/kgx/source/tsv_source.py
+++ b/kgx/source/tsv_source.py
@@ -38,7 +38,16 @@ class TsvSource(Source):
             Prefix to IRI map
 
         """
-        self.prefix_manager.set_prefix_map(m)
+        # Use update (additive) rather than set (destructive). The base
+        # PrefixManager loads ~600 default prefix mappings from the JSON-LD
+        # context (HGNC, NCBIGene, MONDO, …) in __init__; calling
+        # `set_prefix_map({})` here — as the transformer does when no
+        # caller-supplied prefix_map is provided — would discard all of them
+        # and leave only the hardcoded biolink/owlstar/MONARCH triplet.
+        # That broke contraction of identifiers.org/hgnc/, identifiers.org/ncbigene/,
+        # and many other URI prefixes for every TSV-derived source (including
+        # ObographSource, which inherits from this).
+        self.prefix_manager.update_prefix_map(m)
 
     def set_reverse_prefix_map(self, m: Dict) -> None:
         """

--- a/tests/resources/obograph_curie_and_predicate.json
+++ b/tests/resources/obograph_curie_and_predicate.json
@@ -1,0 +1,41 @@
+{
+  "graphs": [
+    {
+      "id": "test",
+      "nodes": [
+        {
+          "id": "http://identifiers.org/ncbigene/698782",
+          "lbl": "MLH1",
+          "type": "CLASS"
+        },
+        {
+          "id": "http://identifiers.org/hgnc/5",
+          "lbl": "A1BG",
+          "type": "CLASS"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/NCBITaxon_9544",
+          "lbl": "Macaca mulatta",
+          "type": "CLASS"
+        },
+        {
+          "id": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
+          "lbl": "Homo sapiens",
+          "type": "CLASS"
+        }
+      ],
+      "edges": [
+        {
+          "sub": "http://identifiers.org/ncbigene/698782",
+          "pred": "http://purl.obolibrary.org/obo/RO_0002162",
+          "obj": "http://purl.obolibrary.org/obo/NCBITaxon_9544"
+        },
+        {
+          "sub": "http://identifiers.org/hgnc/5",
+          "pred": "http://purl.obolibrary.org/obo/RO_0002162",
+          "obj": "http://purl.obolibrary.org/obo/NCBITaxon_9606"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_source/test_obograph_source.py
+++ b/tests/unit/test_source/test_obograph_source.py
@@ -28,7 +28,12 @@ def test_read_obograph1():
                 nodes[rec[0]] = rec[1]
 
     assert len(nodes) == 176
-    assert len(edges) == 205
+    # Was 205 prior to the predicate-mapping fix: two distinct relations
+    # (BFO:0000050 and RO:0002211) between GO:0007165 and GO:0008150 were both
+    # silently demoted to biolink:related_to and produced colliding deterministic
+    # edge ids, conflating them in the dict. With BFO:0000050 now correctly
+    # mapped to biolink:part_of, all three edges are kept distinct.
+    assert len(edges) == 206
 
     n1 = nodes["GO:0003677"]
     assert n1["id"] == "GO:0003677"
@@ -91,7 +96,12 @@ def test_read_jsonl2():
                 nodes[rec[0]] = rec[1]
 
     assert len(nodes) == 176
-    assert len(edges) == 205
+    # Was 205 prior to the predicate-mapping fix: two distinct relations
+    # (BFO:0000050 and RO:0002211) between GO:0007165 and GO:0008150 were both
+    # silently demoted to biolink:related_to and produced colliding deterministic
+    # edge ids, conflating them in the dict. With BFO:0000050 now correctly
+    # mapped to biolink:part_of, all three edges are kept distinct.
+    assert len(edges) == 206
 
     n1 = nodes["GO:0003677"]
     assert n1["id"] == "GO:0003677"
@@ -265,6 +275,64 @@ def test_error_detection():
         t.write_report(None, "Error")
     if len(t.get_errors("Warning")) > 0:
         t.write_report(None, "Warning")
+
+
+def test_identifiers_org_uris_contracted_via_transform():
+    """
+    Regression: when running through ``transform()``, the prefix manager's
+    ~600 default JSON-LD context mappings used to be wiped out by
+    ``TsvSource.set_prefix_map({})``, leaving non-OBO IRIs uncontracted in the
+    TSV output. After the fix, identifiers.org/{hgnc,ncbigene} URIs land as
+    proper CURIEs.
+    """
+    output_basename = os.path.join(TARGET_DIR, "obograph_curie_and_predicate")
+    transform(
+        inputs=[os.path.join(RESOURCE_DIR, "obograph_curie_and_predicate.json")],
+        input_format="obojson",
+        output=output_basename,
+        output_format="tsv",
+        stream=False,
+    )
+
+    tin = Transformer()
+    g = TsvSource(tin).parse(
+        filename=output_basename + "_nodes.tsv", format="tsv"
+    )
+    nodes = {}
+    for rec in g:
+        if rec and len(rec) != 4:
+            nodes[rec[0]] = rec[1]
+
+    # Node ids are CURIEs, not IRIs. The original IRI is preserved in `iri`.
+    assert "NCBIGene:698782" in nodes
+    assert nodes["NCBIGene:698782"]["iri"] == "http://identifiers.org/ncbigene/698782"
+    assert "HGNC:5" in nodes
+    assert nodes["HGNC:5"]["iri"] == "http://identifiers.org/hgnc/5"
+
+
+def test_obograph_predicate_mapping_uses_curie():
+    """
+    Regression: ``ObographSource.read_edge`` used to pass the IRI to
+    ``bmt.Toolkit.get_element_by_mapping``, which only recognizes CURIE form.
+    The lookup silently returned None and well-mapped RO predicates fell
+    through to the catch-all biolink:related_to. After the fix, RO:0002162
+    resolves to its proper biolink slot (in_taxon).
+    """
+    t = Transformer()
+    s = ObographSource(t)
+    g = s.parse(os.path.join(RESOURCE_DIR, "obograph_curie_and_predicate.json"))
+
+    edges = []
+    for rec in g:
+        if rec and len(rec) == 4:
+            edges.append(rec[3])
+
+    taxon_edges = [e for e in edges if e.get("relation") == "RO:0002162"]
+    assert len(taxon_edges) == 2
+    for e in taxon_edges:
+        assert e["predicate"] == "biolink:in_taxon", (
+            f"expected biolink:in_taxon for RO:0002162, got {e['predicate']!r}"
+        )
 
 
 def test_phenio_obojson_to_tsv():


### PR DESCRIPTION
## Summary

Two related bugs in the obograph TSV pipeline that together caused obojson IRIs to land as URIs (instead of CURIEs) in TSV output and well-mapped RO relations like `RO:0002162` (in_taxon) to be demoted to `biolink:related_to`.

- **`TsvSource.set_prefix_map` and `SssomSource.set_prefix_map`** now use `update_prefix_map` (additive) rather than `set_prefix_map` (destructive). The base `PrefixManager` loads ~600 default JSON-LD prefix mappings in `__init__`; the transformer's `source.set_prefix_map({})` call was wiping them, leaving only the three hardcoded `biolink`/`owlstar`/`MONARCH` entries that `set_prefix_map` re-adds.
- **`ObographSource.read_edge`** passes the already-computed CURIE (not the IRI) to `bmt`'s `get_element_by_mapping`. `bmt` only recognizes CURIE form, so the IRI lookup silently returned `None` and edges fell through to the catch-all `biolink:related_to`. Six common `RO:*` relations get proper biolink slots after this fix (`in_taxon`, `causes`, `has_participant`, `disrupts`, `caused_by`, `expresses`).

Closes #546.
Closes #547.

## Test plan

- [x] Two new unit tests in `tests/unit/test_source/test_obograph_source.py` (one per bug), backed by a small obograph fixture (`tests/resources/obograph_curie_and_predicate.json`).
- [x] Adjusted `test_read_obograph1`/`test_read_jsonl2` expected edge count from 205 to 206. Previously, two distinct relations between the same node pair (`BFO:0000050` and `RO:0002211` both between `GO:0007165` and `GO:0008150`) were silently demoted to `biolink:related_to` and produced colliding deterministic edge ids (`{sub}-{predicate}-{obj}`) that conflated in the test's dict. With `BFO:0000050` now correctly mapped to `biolink:part_of`, all three edges are kept distinct. A code comment in the test explains this.
- [x] Full unit test suite passes (335 passed, 8 skipped — the skipped ones require external services like neo4j/arango).